### PR TITLE
Symfony v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
         "php": "^8.0.0",
         "ext-simplexml": "*",
         "php-ds/php-ds": "^v1.4.1",
-        "symfony/filesystem": "^6.0",
-        "symfony/console": "^6.0"
+        "symfony/console": "^6.0 | ^7.0"
     },
     "require-dev": {
         "kahlan/kahlan": "^5.1.3",


### PR DESCRIPTION
* Allow symfony/console version ^7
* Removed direct dependency of symfony/filesystem

Using symfony/console version ^7 doesn't need any code changes and symfony/filesystem is not directly used within the codebase, so no direct dependency is needed.